### PR TITLE
Add Telegram and WhatsApp fields to user profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 
 # Ignore .env
 .env
+.env.local
 
 # REDIS
 dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 
 # REDIS
 dump.rdb
+
+.vscode/

--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,6 @@ gem 'kaminari'
 gem 'activeadmin_json_editor', '~> 0.0.7'
 
 gem 'sidekiq-scheduler'
+
+## added 7/30
+gem 'nio4r', '~> 2.5.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       net-protocol
       timeout
     netrc (0.11.0)
-    nio4r (2.5.8)
+    nio4r (2.5.9)
     nokogiri (1.13.6-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
@@ -372,6 +372,7 @@ PLATFORMS
   arm64-darwin-20
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -394,6 +395,7 @@ DEPENDENCIES
   jwt
   kaminari
   knockapi
+  nio4r (~> 2.5.9)
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.3)

--- a/app/controllers/api/V1/user_profiles_controller.rb
+++ b/app/controllers/api/V1/user_profiles_controller.rb
@@ -27,7 +27,7 @@ module Api
 
       def user_params
         params.require(:user_profile).permit(:image, :email, :name, :twitter, :timezone, :available_from,
-                                            :available_to, :weekend_offline)
+        :available_to, :weekend_offline, :telegram_user_id, :telegram_username, :whatsapp_country_code, :whatsapp_number)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,12 @@ class User < ApplicationRecord
   validates :available_to,
     numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 23 }, allow_blank: true
 
+    validates :telegram_user_id, uniqueness: true, allow_nil: true
+    validates :telegram_username, uniqueness: true, allow_nil: true
+    validates :whatsapp_country_code, presence: true, if: -> { whatsapp_number.present? }
+    validates :whatsapp_number, presence: true, if: -> { whatsapp_country_code.present? }
+    
+
   has_many :lists, foreign_key: :seller_id
   has_many :buy_orders, foreign_key: :buyer_id, class_name: 'Order'
   has_many :sell_orders, foreign_key: :seller_id, class_name: 'Order'

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,6 +1,6 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :address, :created_at, :trades, :image_url, :name, :twitter, :verified,
-    :completion_rate, :timezone, :available_from, :available_to, :weekend_offline, :online
+    :completion_rate, :timezone, :available_from, :available_to, :weekend_offline, :online, :telegram_user_id, :telegram_username, :whatsapp_country_code, :whatsapp_number
 
   has_many :contracts do
     object.contracts.order(created_at: :desc)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,9 @@
 require_relative "boot"
 
+## added 7/30 for use in dev with prod db
+# require 'dotenv/load'
+
+
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"

--- a/db/migrate/20240730190525_add_telegram_and_whatsapp_to_users.rb
+++ b/db/migrate/20240730190525_add_telegram_and_whatsapp_to_users.rb
@@ -1,0 +1,10 @@
+class AddTelegramAndWhatsappToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :telegram_user_id, :bigint
+    add_column :users, :telegram_username, :string
+    add_column :users, :whatsapp_country_code, :string
+    add_column :users, :whatsapp_number, :string
+
+    add_index :users, :telegram_user_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_13_195219) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_30_190525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "active_admin_comments", force: :cascade do |t|
-    t.string "namespace"
-    t.text "body"
-    t.string "resource_type"
-    t.bigint "resource_id"
-    t.string "author_type"
-    t.bigint "author_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
-    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource"
-  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -110,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_13_195219) do
     t.decimal "points"
     t.decimal "locked_value"
     t.index ["user_id", "chain_id", "address", "version"], name: "index_contracts_on_user_id_and_chain_id_and_address_and_version", unique: true
+    t.index ["user_id", "chain_id", "address"], name: "index_contracts_on_user_id_and_chain_id_and_address", unique: true
     t.index ["user_id"], name: "index_contracts_on_user_id"
   end
 
@@ -304,9 +291,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_13_195219) do
     t.integer "available_to"
     t.boolean "weekend_offline", default: false
     t.integer "imported_orders_count", default: 0
+    t.bigint "telegram_user_id"
+    t.string "telegram_username"
+    t.string "whatsapp_country_code"
+    t.string "whatsapp_number"
     t.index "lower((address)::text)", name: "index_users_on_lower_address", unique: true
     t.index ["merchant"], name: "index_users_on_merchant"
     t.index ["name"], name: "index_users_on_name", unique: true
+    t.index ["telegram_user_id"], name: "index_users_on_telegram_user_id", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
This pull request introduces new fields to accommodate Telegram and WhatsApp integration in user profiles. The changes include:

Database schema updates:

Added telegram_user_id (bigint)
Added telegram_username (string)
Added whatsapp_country_code (string)
Added whatsapp_number (string)

Model updates:

Added validations for new fields in the User model
Ensured uniqueness for Telegram fields
Added presence validations for WhatsApp fields

Controller updates:

Updated user_params in UserProfilesController to permit new fields

Serializer updates:

Added new fields to UserSerializer

Dependencies:

Updated nio4r gem to version 2.5.9

These changes will allow users to associate their Telegram and WhatsApp accounts with their profiles, enhancing communication options within the platform.

With this, I will create a preview of the tgwa branch and do some testing to find bugs and such.

Feedback welcome!