### PR TITLE
Integrate Telegram notifications and add user fields for Telegram and WhatsApp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,6 @@ gem 'sidekiq-scheduler'
 
 ## added 7/30
 gem 'nio4r', '~> 2.5.9'
+
+## added 8/7
+gem 'telegram-bot-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,10 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.18)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -114,12 +118,16 @@ GEM
     cancancan (3.5.0)
     case_transform (0.2)
       activesupport
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     crass (1.0.6)
     debug (1.5.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -134,6 +142,7 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    dry-inflector (1.1.0)
     email_address (0.2.4)
       simpleidn
     erubi (1.10.0)
@@ -152,6 +161,13 @@ GEM
       railties (>= 5.0.0)
     faker (2.21.0)
       i18n (>= 1.8.11, < 2)
+    faraday (2.10.1)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.1.1)
+      net-http
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -172,6 +188,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     inherited_resources (1.13.1)
       actionpack (>= 5.2, < 7.1)
       has_scope (~> 0.6)
@@ -202,6 +219,7 @@ GEM
     keccak (1.3.0)
     knockapi (0.4.5)
     konstructor (1.0.2)
+    logger (1.6.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -216,6 +234,9 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.5.2)
+    multipart-post (2.4.1)
+    net-http (0.4.1)
+      uri
     net-imap (0.2.3)
       digest
       net-protocol
@@ -349,7 +370,13 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     strscan (3.0.3)
+    telegram-bot-ruby (0.23.0)
+      dry-inflector
+      faraday (~> 2.0)
+      faraday-multipart (~> 1.0)
+      virtus (~> 2.0)
     thor (1.2.1)
+    thread_safe (0.3.6)
     tilt (2.1.0)
     timeout (0.3.0)
     tzinfo (2.0.4)
@@ -358,9 +385,14 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     uniform_notifier (1.16.0)
+    uri (0.13.0)
     valid_email2 (4.0.4)
       activemodel (>= 3.2)
       mail (~> 2.5)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.7.5)
@@ -407,6 +439,7 @@ DEPENDENCIES
   sidekiq-scheduler
   sprockets-rails (~> 3.4)
   strscan (= 3.0.3)
+  telegram-bot-ruby
   tzinfo-data
   valid_email2
 

--- a/README.md
+++ b/README.md
@@ -45,5 +45,3 @@ OpenPeer uses escrow contracts to enable peer-to-peer trades in stablecoins with
 6. If either party believes that the other has violated the agreed upon terms, they can initiate a dispute through the OpenPeer UI. The protocol provides a mechanism for dispute resolution by facilitating communication between the two parties. If the dispute cannot be resolved through communication or mediation, a panel of arbitrators vetted and approved by the OpenPeer community will make a binding decision.
 
 Overall, the OpenPeer protocol is designed to provide a fair and reliable way for buyers and sellers to trade in stablecoins without the need for a centralized intermediary.
-
-## test

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register User do
   menu priority: 3
   actions :index, :show, :edit, :update
-  permit_params :merchant, :name, :twitter, :verified, :imported_orders_count
+  permit_params :merchant, :name, :twitter, :verified, :imported_orders_count, :telegram_user_id, :telegram_username, :whatsapp_country_code, :whatsapp_number
 
   show do
     attributes_table do
@@ -9,6 +9,10 @@ ActiveAdmin.register User do
       row :name
       row :email
       row :twitter
+      row :telegram_user_id
+      row :telegram_username
+      row :whatsapp_country_code
+      row :whatsapp_number
       row :verified
       row :merchant
       row :image

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -1,4 +1,5 @@
 require "knock"
+require 'telegram/bot'
 
 class NotificationWorker
   include Sidekiq::Worker
@@ -25,25 +26,27 @@ class NotificationWorker
             when SELLER_ESCROWED, SELLER_RELEASED, DISPUTE_OPENED
               buyer
             when ORDER_CANCELLED
-              order.cancelled_by.id == seller.id ? buyer : seller
+              order.cancelled_by&.id == seller.id ? buyer : seller
             when DISPUTE_RESOLVED
               winner
             end
 
-    actor_profile = { id: actor&.address, name: actor&.name, email: actor&.email }
+    if actor.nil? || actor.address.nil?
+      Rails.logger.error("Actor or actor address is nil for order #{order.id}")
+      return
+    end
+
+    actor_profile = { id: actor&.address, name: actor&.name, email: actor&.email, telegram_user_id: actor&.telegram_user_id }
     recipients = [actor_profile]
 
     if order.dispute? || type == DISPUTE_RESOLVED
-      recipients = [{ id: seller.address, name: seller.name, email: seller.email },
-                    { id: buyer.address, name: buyer.name, email: buyer.email }]
+      recipients = [{ id: seller.address, name: seller.name, email: seller.email, telegram_user_id: seller.telegram_user_id  },
+                    { id: buyer.address, name: buyer.name, email: buyer.email, telegram_user_id: buyer.telegram_user_id }]
     end
 
     cancelled_by = order.cancelled_by
-    Knock::Workflows.trigger(
-      key: type,
-      actor: actor_profile,
-      recipients: recipients,
-      data: {
+
+    data = {
         username: actor&.name.presence || small_wallet_address(actor&.address || ''),
         seller: seller.name.presence || small_wallet_address(seller.address),
         buyer: buyer.name.presence || small_wallet_address(buyer.address),
@@ -58,7 +61,35 @@ class NotificationWorker
         winner: winner ? (winner.name.presence || small_wallet_address(winner.address)) : nil,
         payment_method: order.payment_method&.bank.name
       }
+
+    Knock::Workflows.trigger(
+      key: type,
+      actor: actor_profile,
+      recipients: recipients,
+      data: data
     )
+
+    send_telegram_notification(type, actor, recipients, data)
+  end
+
+  def send_telegram_notification(type, actor, recipients, data)
+    bot = Telegram::Bot::Client.new(ENV['TELEGRAM_BOT_TOKEN'])
+    
+    recipients.each do |recipient|
+      next unless recipient[:telegram_user_id]
+  
+      message = format_telegram_message(type, actor, data)
+      begin
+        response = bot.api.send_message(chat_id: recipient[:telegram_user_id], text: message)
+        if response['ok']
+          Rails.logger.info("Telegram notification sent successfully to user #{recipient[:telegram_user_id]} for order #{data[:uuid]}")
+        else
+          Rails.logger.warn("Failed to send Telegram notification to user #{recipient[:telegram_user_id]} for order #{data[:uuid]}: #{response['description']}")
+        end
+      rescue Telegram::Bot::Exceptions::ResponseError => e
+        Rails.logger.error("Error sending Telegram notification to user #{recipient[:telegram_user_id]} for order #{data[:uuid]}: #{e.message}")
+      end
+    end
   end
 
   private
@@ -66,4 +97,40 @@ class NotificationWorker
   def small_wallet_address(address, length = 4)
     "#{address[0, length]}..#{address[-length, length]}"
   end
+
+  def format_telegram_message(type, actor, data)
+    case type
+    when NEW_ORDER
+      "New order received from #{data[:buyer]} for #{data[:token_amount]} #{data[:token]} (#{data[:fiat_amount]} #{data[:fiat]})"
+    when SELLER_ESCROWED
+      "Seller #{data[:seller]} has escrowed #{data[:token_amount]} #{data[:token]} for your order"
+    when BUYER_PAID
+      "Buyer #{data[:buyer]} has marked the payment as sent for #{data[:fiat_amount]} #{data[:fiat]}"
+    when SELLER_RELEASED
+      "Seller #{data[:seller]} has released #{data[:token_amount]} #{data[:token]} for your order"
+    when ORDER_CANCELLED
+      "Order #{data[:uuid]} has been cancelled by #{data[:cancelled_by]}"
+    when DISPUTE_OPENED
+      "A dispute has been opened for order #{data[:uuid]}"
+    when DISPUTE_RESOLVED
+      "The dispute for order #{data[:uuid]} has been resolved. Winner: #{data[:winner]}"
+    else
+      "Order #{data[:uuid]} status update: #{type}"
+    end
+  end
+
+  def self.test_notification(user_id)
+    user = User.find(user_id)
+    data = {
+      username: user.name || small_wallet_address(user.address),
+      uuid: 'TEST123',
+      token_amount: '100',
+      token: 'TEST',
+      fiat_amount: '1000',
+      fiat: 'USD'
+    }
+    
+    new.send_telegram_notification('test', user, [user], data)
+  end
+  
 end

--- a/test_notifs.rb
+++ b/test_notifs.rb
@@ -57,3 +57,5 @@ notification_types.each do |type|
 end
 
 puts "All notifications tested!"
+
+// TODO: have the script clean up after itself.

--- a/test_notifs.rb
+++ b/test_notifs.rb
@@ -1,0 +1,59 @@
+seller = User.find_by!(telegram_user_id: 468259635)
+buyer = User.find_by!(telegram_user_id: 468259635)
+
+token = Token.first
+
+fiat_currency = FiatCurrency.first
+
+payment_method = ListPaymentMethod.create!(
+  user: seller,
+  bank: Bank.first,
+  values: { "upi_id" => "test123@upi" }
+)
+
+list = List.create!(
+  seller: seller, 
+  token: token, 
+  fiat_currency: fiat_currency, 
+  chain_id: token.chain_id,
+  payment_time_limit: 60,
+  banks: [Bank.first],
+  margin: 0.01,
+  margin_type: :fixed,
+  payment_method: payment_method
+  )
+
+# Create the order
+order = Order.create!(
+  list: list,
+  buyer: buyer,
+  seller: seller,
+  fiat_amount: 100,
+  token_amount: 1,
+  status: :created,
+  chain_id: list.chain_id,
+  payment_method: OrderPaymentMethod.create!(
+    user: buyer,
+    bank: Bank.first,
+    values: { "upi_id" => "buyer123@upi" }
+  )
+)
+
+# Test all notification types
+notification_types = [
+  NotificationWorker::NEW_ORDER,
+  NotificationWorker::SELLER_ESCROWED,
+  NotificationWorker::BUYER_PAID,
+  NotificationWorker::SELLER_RELEASED,
+  NotificationWorker::ORDER_CANCELLED,
+  NotificationWorker::DISPUTE_OPENED,
+  NotificationWorker::DISPUTE_RESOLVED
+]
+
+notification_types.each do |type|
+  puts "Testing notification: #{type}"
+  NotificationWorker.new.perform(type, order.id)
+  sleep 2 # Wait a bit between notifications
+end
+
+puts "All notifications tested!"


### PR DESCRIPTION
This pull request adds Telegram notification functionality and introduces new user fields for Telegram and WhatsApp contact information. Key changes include:

1. Added 'telegram-bot-ruby' gem to enable Telegram bot integration.
2. Updated User model in ActiveAdmin to include new fields:
- telegram_user_id
- telegram_username
- whatsapp_country_code
- whatsapp_number
3. Enhanced NotificationWorker to support Telegram notifications:
- Implemented send_telegram_notification method
- Added format_telegram_message method to create appropriate messages for different notification types
- Updated perform method to include Telegram user IDs in recipient data
4. Created test_notifs.rb script to test various notification types

These changes will allow the application to send notifications via Telegram and store additional contact information for users, improving communication capabilities within the platform.