### PR TITLE
Implement Unique-Code-Based Method for Telegram Bot Integration for User Notifications

### DIFF
--- a/app/controllers/telegram_controller.rb
+++ b/app/controllers/telegram_controller.rb
@@ -1,0 +1,63 @@
+# app/controllers/telegram_controller.rb
+class TelegramController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def webhook
+    # Parse the incoming update from Telegram
+    update = Telegram::Bot::Types::Update.new(params)
+
+    # Check if the update contains a message
+    if update.message
+      # Check if the message is a /start command
+      if update.message.text.start_with?('/start')
+        # Extract the unique identifier from the /start command
+        unique_identifier = extract_unique_identifier(update.message.text)
+
+        if unique_identifier
+          # Find the user by their unique identifier
+          user = User.find_by(unique_identifier: unique_identifier)
+
+          if user
+            # User found, extract Telegram chat_id and username
+            chat_id = update.message.chat.id
+            username = update.message.from.username
+
+            # Update the user's Telegram details in the database
+            user.update(telegram_userid: chat_id, telegram_username: username)
+
+            # Send a welcome message to the user
+            send_welcome_message(chat_id, user.name)
+          else
+            # User not found, handle the case
+            send_message(update.message.chat.id, "User not found. Please make sure you entered the correct unique identifier.")
+          end
+        else
+          # Unique identifier not provided, handle the case
+          send_message(update.message.chat.id, "Please provide your unique identifier after the /start command.")
+        end
+      end
+    end
+
+    # Respond with a success status
+    head :ok
+  end
+
+  private
+
+  def extract_unique_identifier(text)
+    # Extract the unique identifier from the /start command
+    text.split(' ').second
+  end
+
+  def send_message(chat_id, text)
+    # Send a message to the specified chat ID
+    Telegram::Bot::Client.run(ENV['TELEGRAM_BOT_TOKEN']) do |bot|
+      bot.api.send_message(chat_id: chat_id, text: text)
+    end
+  end
+
+  def send_welcome_message(chat_id, user_name)
+    message = "GM #{user_name}. You have just subscribed to receive OpenPeer trade notifications. Your unique chat ID is #{chat_id}. Please make sure I'm not muted!"
+    send_message(chat_id, message)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  before_validation :generate_unique_identifier, on: :create
   validates :address, presence: true, uniqueness: { case_sensitive: false }
   validates :email, 'valid_email_2/email': true, allow_blank: true
   validates :name, uniqueness: { case_sensitive: false }, allow_blank: true
@@ -59,5 +60,11 @@ class User < ApplicationRecord
 
   before_create do
     self.address = Eth::Address.new(self.address).checksummed
+  end
+
+  private
+
+  def generate_unique_identifier
+    self.unique_identifier ||= SecureRandom.uuid
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :address, :created_at, :trades, :image_url, :name, :twitter, :verified,
+  attributes :id, :address, :unique_identifier, :created_at, :trades, :image_url, :name, :twitter, :verified,
     :completion_rate, :timezone, :available_from, :available_to, :weekend_offline, :online, :telegram_user_id, :telegram_username, :whatsapp_country_code, :whatsapp_number
 
   has_many :contracts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,5 +42,6 @@ Rails.application.routes.draw do
     get '/blast/webhooks', to: 'blast_webhooks#index'
     post '/blast/webhooks', to: 'blast_webhooks#create'
     post '/blast/webhooks/escrows', to: 'blast_webhooks#escrows'
+    post '/telegram/webhook', to: 'telegram#webhook'
   end
 end

--- a/db/migrate/20240820153941_add_unique_identifier_to_users.rb
+++ b/db/migrate/20240820153941_add_unique_identifier_to_users.rb
@@ -1,0 +1,7 @@
+class AddUniqueIdentifierToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :unique_identifier, :string
+    add_index :users, :unique_identifier, unique: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_30_190525) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_20_153941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -295,10 +295,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_190525) do
     t.string "telegram_username"
     t.string "whatsapp_country_code"
     t.string "whatsapp_number"
+    t.string "unique_identifier"
     t.index "lower((address)::text)", name: "index_users_on_lower_address", unique: true
     t.index ["merchant"], name: "index_users_on_merchant"
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["telegram_user_id"], name: "index_users_on_telegram_user_id", unique: true
+    t.index ["unique_identifier"], name: "index_users_on_unique_identifier", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/lib/tasks/generate_user_identifiers.rake
+++ b/lib/tasks/generate_user_identifiers.rake
@@ -1,0 +1,12 @@
+# lib/tasks/generate_user_identifiers.rake
+namespace :users do
+  desc 'Generate unique identifiers for users without one'
+  task generate_identifiers: :environment do
+    User.where(unique_identifier: nil).find_each do |user|
+      user.send(:generate_unique_identifier)
+      user.save!
+      puts "User: #{user.name || 'N/A'}, Wallet: #{user.address}, Unique Identifier: #{user.unique_identifier}"
+    end
+    puts 'Unique identifiers generated for all users.'
+  end
+end


### PR DESCRIPTION
1. Added a new `TelegramController` to handle webhook updates from Telegram.
2. Created a new route `/telegram/webhook` to receive updates from the Telegram bot.
3. Updated the `User` model to include a `unique_identifier` field and a method to generate it.
4. Modified the `UserSerializer` to include the `unique_identifier` in the serialized output.
5. Added a database migration to add the `unique_identifier` column to the `users` table.
6. Created a rake task `generate_user_identifiers` to populate existing users with unique identifiers.

Key features:
- Users can now start the Telegram bot with their unique identifier to enable notifications.
- The system saves the user's Telegram chat ID and username when they start the bot.
- A welcome message is sent to users upon successful connection.