### PR TITLE
Remove the condition that skips the notification for instant escrow ads

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -12,6 +12,9 @@ class NotificationWorker
   DISPUTE_OPENED = 'dispute-opened'
   DISPUTE_RESOLVED = 'dispute-resolved'
 
+    # Remove the condition that skips the notification for instant escrow ads
+    # return if type === NEW_ORDER && (order.list.instant? || order.list.buy_list?)
+
   def perform(type, order_id)
     order = Order.includes(:list, :buyer, :cancelled_by).find(order_id)
     seller = order.seller


### PR DESCRIPTION
This PR removes the condition that previously skipped notifications for instant escrow and buy list advertisements. The change affects the `NotificationWorker` class in the `app/workers/notification_worker.rb` file.

### Changes:
- Removed the following condition:
  ```ruby
  return if type === NEW_ORDER && (order.list.instant? || order.list.buy_list?)
  ```

### Rationale:
By removing this condition, we ensure that notifications are sent for all types of advertisements, including instant escrow and buy list ads. This change improves the consistency of our notification system and ensures that users receive updates for all relevant order activities.

### Testing:
- [ ] Verify that notifications are now sent for instant escrow ads
- [ ] Verify that notifications are now sent for buy list ads