### PR TITLE
Update error message for existing username

### DIFF
--- a/app/controllers/api/V1/user_profiles_controller.rb
+++ b/app/controllers/api/V1/user_profiles_controller.rb
@@ -30,7 +30,7 @@ module Api
           else
             Rails.logger.error("User update failed: #{current_user.errors.full_messages.join(', ')}")
             if current_user.errors[:name].include?("has already been taken")
-              render json: { data: { message: 'Username already exists', errors: current_user.errors.full_messages }}, status: :unprocessable_entity
+              render json: { data: { message: 'Username already exists. Please try a different one.', errors: current_user.errors.full_messages }}, status: :unprocessable_entity
             else
               render json: { data: { message: 'User not updated', errors: current_user.errors.full_messages }}, status: :unprocessable_entity
             end


### PR DESCRIPTION
This pull request updates the error message displayed when a user attempts to update their profile with a username that already exists. The change aims to provide a clearer and more user-friendly message.

Changes made:
- Modified the error message in `app/controllers/api/V1/user_profiles_controller.rb`
- Updated from "Username already exists" to "Username already exists. Please try a different one."

This change enhances the user experience by providing more explicit guidance when a username conflict occurs during profile updates.