### PR TITLE
Add accept_only_trusted field to List model and API

### DIFF
--- a/app/controllers/api/V1/list_management_controller.rb
+++ b/app/controllers/api/V1/list_management_controller.rb
@@ -1,3 +1,5 @@
+# app/controllers/api/V1/list_management_controller.rb
+
 module Api
   module V1
     class ListManagementController < JwtController

--- a/app/controllers/api/V1/list_management_controller.rb
+++ b/app/controllers/api/V1/list_management_controller.rb
@@ -47,7 +47,7 @@ module Api
         params.require(:list)
               .permit(:margin_type, :margin, :total_available_amount, :limit_min, :limit_max, :terms,
                       :token_id, :fiat_currency_id, :type, :deposit_time_limit, :payment_time_limit,
-                      :accept_only_verified, :escrow_type, :chain_id, :price_source, :bank_ids => [])
+                      :accept_only_verified, :escrow_type, :chain_id, :price_source, :accept_only_trusted, :bank_ids => [])
       end
 
       def payment_methods_params
@@ -58,7 +58,7 @@ module Api
         params.require(:list)
               .permit(:id, :margin_type, :margin, :total_available_amount, :limit_min, :limit_max, :terms,
                       :deposit_time_limit, :payment_time_limit, :accept_only_verified, :status,
-                      :price_source, :bank_ids => [])
+                      :price_source, :accept_only_trusted, :bank_ids => [])
       end
 
       private

--- a/app/controllers/api/V1/lists_controller.rb
+++ b/app/controllers/api/V1/lists_controller.rb
@@ -1,3 +1,5 @@
+# app/controllers/api/V1/lists_controller.rb
+
 module Api
   module V1
     class ListsController < BaseController

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,3 +1,5 @@
+# app/models/list.rb
+
 class List < ApplicationRecord
   enum status: [:created, :active, :closed], _default: :active
   enum margin_type: [:fixed, :percentage]

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -20,6 +20,7 @@ class List < ApplicationRecord
   validate :ensure_bank_or_payment_methods_present
   validates :chain_id, presence: true
   validates :payment_time_limit, numericality: { greater_than_or_equal_to: 15, less_than_or_equal_to: 1440 }
+  validates :accept_only_trusted, inclusion: { in: [true, false] }
 
 
   def price

--- a/app/serializers/list_serializer.rb
+++ b/app/serializers/list_serializer.rb
@@ -1,7 +1,7 @@
 class ListSerializer < ActiveModel::Serializer
   attributes :id, :automatic_approval, :chain_id, :limit_min, :limit_max, :margin_type,
              :margin, :status, :terms, :total_available_amount, :price, :type, :deposit_time_limit,
-             :payment_time_limit, :accept_only_verified, :escrow_type, :contract, :price_source
+             :payment_time_limit, :accept_only_verified, :escrow_type, :contract, :price_source, :accept_only_trusted
 
   belongs_to :seller
   belongs_to :token

--- a/db/migrate/20240925173252_add_accept_only_trusted_to_lists.rb
+++ b/db/migrate/20240925173252_add_accept_only_trusted_to_lists.rb
@@ -1,0 +1,6 @@
+# db/migrate/20231103133021_add_accept_only_trusted_to_lists.rb
+class AddAcceptOnlyTrustedToLists < ActiveRecord::Migration[7.0]
+  def change
+    add_column :lists, :accept_only_trusted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_13_212957) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_25_173252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -172,6 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_13_212957) do
     t.boolean "accept_only_verified", default: false
     t.integer "escrow_type", default: 0
     t.integer "price_source", default: 0
+    t.boolean "accept_only_trusted", default: false
     t.index ["bank_id"], name: "index_lists_on_bank_id"
     t.index ["chain_id", "seller_id"], name: "index_lists_on_chain_id_and_seller_id"
     t.index ["fiat_currency_id"], name: "index_lists_on_fiat_currency_id"


### PR DESCRIPTION
This PR introduces a new `accept_only_trusted` boolean field to the List model. This feature allows list creators to specify whether they want to accept offers only from trusted users.

## Changes

- Add `accept_only_trusted` column to the `lists` table
- Update List model to include validation for the new field
- Modify ListSerializer to include the new field in API responses
- Update ListManagementController to permit the new field in strong params
- Add migration file for the new column

- Default value for `accept_only_trusted` is set to `false` to maintain backwards compatibility

Please review and let me know if any changes are needed.